### PR TITLE
Update Paho JavaScript library to 1.1.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
       <link rel="stylesheet" href="index-style.css">
       <link rel="stylesheet" href="topNav.css">
       <link rel="stylesheet" href="sensors-style.css">
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/paho-mqtt/1.0.2/mqttws31.min.js" type="text/javascript"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/paho-mqtt/1.1.0/paho-mqtt.min.js" type="text/javascript"></script>
       <script src="mqtt_webSocket.js" type="text/javascript"></script>
 
    </head>

--- a/mqtt_webSocket.js
+++ b/mqtt_webSocket.js
@@ -17,7 +17,7 @@ function startConnect() {
     document.getElementById("messages").innerHTML += '<span>Using the following client value: ' + clientID + '</span><br/>';
 
     // Initialize new Paho client connection
-    client = new Paho.MQTT.Client(host, Number(port), clientID);
+    client = new Paho.Client(host, Number(port), clientID);
 
     //initialize new sensor_listener object
     //sensors = new listener();


### PR DESCRIPTION
Update Paho JavaScript library to the latest stable version 1.1.0. The client's namepsace was renamed from Paho.MQTT to Paho.